### PR TITLE
FEAT - Local docker image support

### DIFF
--- a/panoramacli/panorama-cli
+++ b/panoramacli/panorama-cli
@@ -325,7 +325,10 @@ def build_package(docker_build=True):
         os.remove(asset_path)
     
     if docker_build:
-        commands = ["TMPDIR=$(pwd) docker build -t " + asset_name + " " + args.package_path + " --pull", "docker export --output=" + asset_name + ".tar $(docker create " + asset_name + ":latest)"]
+        if args.local_image:
+            commands = ["TMPDIR=$(pwd) docker build -t " + asset_name + " " + args.package_path, "docker export --output=" + asset_name + ".tar $(docker create " + asset_name + ":latest)"]
+        else:
+            commands = ["TMPDIR=$(pwd) docker build -t " + asset_name + " " + args.package_path + " --pull", "docker export --output=" + asset_name + ".tar $(docker create " + asset_name + ":latest)"]
     else:
         commands = ["docker export --output=" + asset_name + ".tar $(docker create " + args.container_image_uri + ")"]
     for cmd in commands:
@@ -950,11 +953,13 @@ def main(passed_args=None):
     build_parser = subparsers.add_parser("build", help="(Deprecated) Use build-container instead. Build the package.")
     build_parser.add_argument("--container-asset-name",  required=True, help="Name of the package")
     build_parser.add_argument("--package-path",  required=True, help="Path for the package to be built")
+    build_parser.add_argument("--local-image", action="store_true", help="Allow Docker to use local images rather than pull the latest image")
     build_parser.set_defaults(func=build)
 
     build_parser = subparsers.add_parser("build-container", help="Build the package")
     build_parser.add_argument("--container-asset-name",  required=True, help="Name of the package")
     build_parser.add_argument("--package-path",  required=True, help="Path for the package to be built")
+    build_parser.add_argument("--local-image", action="store_true", help="Allow Docker to use local images rather than pull the latest image")
     build_parser.set_defaults(func=build)
 
     export_parser = subparsers.add_parser("export-container", help="Export a pre-built docker container to your package")


### PR DESCRIPTION
When applied this commit will add the argument `--local-image` to the build_parser subparser. When specified this argument allows docker to use local images where possible, which can be required when the user has built a specific local image they wish to use.

*Issue #, if available:*
When using a local docker image, calling build-container fails due to the --pull argument that is present in the docker build call. 

Default docker call in build_package():
`"TMPDIR=$(pwd) docker build -t " + asset_name + " " + args.package_path + " --pull"`

*Description of changes:*
Added the argument `--local-image` to the build_parser subparser. When invoked this argument will cause the below docker build call to be used instead. If `--local-image` is not provided by the user, the original `docker build` call will be invoked by default. 

Docker call in build_package() when `--local-image` is passed as an argument:
`"TMPDIR=$(pwd) docker build -t " + asset_name + " " + args.package_path + " --pull"`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
