### PR TITLE
Use faster compression setting for GZIP command

### DIFF
--- a/panoramacli/panorama-cli
+++ b/panoramacli/panorama-cli
@@ -343,7 +343,7 @@ def build_package(docker_build=True):
     shutil.copyfile(descriptor_path, descriptor_dst_final_path)
 
     image_name = asset_name + ".tar"
-    commands= ["gzip -9 " + image_name]
+    commands= ["gzip -1 " + image_name]
     for cmd in commands:
         print(cmd)
         return_code, out = execute([cmd], runtime_print_output=True)


### PR DESCRIPTION
`gzip -9` is slow and has limited effect on binary container images. Use `gzip -1`  to reduce time generating `tar.gz` asset for code containers during `build-container` workflow

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
